### PR TITLE
Updated GLUG website URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="images/logo.png" alt="GlugPace Logo" width="200px" height="200px"/>
  </p>
 
-# GLUG PACE [Website](https://glugpace22.tech/)🚀
+# GLUG PACE [Website](https://glugpace.org/)🚀
 
 GLUG PACE is a group of people who works for FOSS. This project is the Official website for the GLUG PACE Community.
 Find out more information at [glugpace](https://github.com/glugpace/).
@@ -48,3 +48,4 @@ Glug PACE is dedicated to building a welcoming, diverse, safe community. We expe
 - [Azlan](https://github.com/azlanajju)
 - [Rabeeh T A](https://github.com/rabeeh-ta)
 - [Sheik Rifaz Ali](https://github.com/rifaz124)
+- [Shakeel Ahammed](https://github.com/shakeelahammedabdulla)


### PR DESCRIPTION
This commit updates the GLUG website URL in the README.md file to reflect the latest changes. The previous URL was outdated, and this update ensures that users can easily access the correct website.

Changes Made:
- Updated GLUG website URL to [new-website-url](https://glugpace.org/) in the README.md file.

Reason for Update:
- The previous website URL was no longer valid.
- This update provides accurate information for users interested in the GLUG website.